### PR TITLE
add signing and verification for YAML annotation signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.DS_Store

--- a/cmd/kubectl-sigstore/sign.go
+++ b/cmd/kubectl-sigstore/sign.go
@@ -55,11 +55,18 @@ func NewCmdSign() *cobra.Command {
 }
 
 func sign(inputDir, imageRef, keyPath, output string, updateAnnotation bool) error {
-	if output == "" {
+	if output == "" && updateAnnotation {
 		output = inputDir + ".signed"
 	}
 
-	_, err := k8smanifest.Sign(inputDir, imageRef, keyPath, output, updateAnnotation)
+	so := &k8smanifest.SignOption{
+		ImageRef:         imageRef,
+		KeyPath:          keyPath,
+		Output:           output,
+		UpdateAnnotation: updateAnnotation,
+	}
+
+	_, err := k8smanifest.Sign(inputDir, so)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil

--- a/cmd/kubectl-sigstore/verify.go
+++ b/cmd/kubectl-sigstore/verify.go
@@ -33,14 +33,12 @@ func NewCmdVerify() *cobra.Command {
 	var filename string
 	var keyPath string
 	var configPath string
-	var cacheDir string
-	var useCache bool
 	cmd := &cobra.Command{
 		Use:   "verify -f <YAMLFILE> [-i <IMAGE>]",
 		Short: "A command to verify Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := verify(filename, imageRef, keyPath, configPath, useCache, cacheDir)
+			err := verify(filename, imageRef, keyPath, configPath)
 			if err != nil {
 				return err
 			}
@@ -52,13 +50,11 @@ func NewCmdVerify() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
-	cmd.PersistentFlags().BoolVar(&useCache, "use-cache", false, "whether to use cache for pulling & verifying image (default: disabled)")
-	cmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", "", "a directory for storing cached data (if empty, not use cache)")
 
 	return cmd
 }
 
-func verify(filename, imageRef, keyPath, configPath string, useCache bool, cacheDir string) error {
+func verify(filename, imageRef, keyPath, configPath string) error {
 	manifest, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -86,10 +82,6 @@ func verify(filename, imageRef, keyPath, configPath string, useCache bool, cache
 	}
 	if keyPath != "" {
 		vo.KeyPath = keyPath
-	}
-	if useCache && cacheDir != "" {
-		vo.UseCache = useCache
-		vo.CacheDir = cacheDir
 	}
 
 	result, err := k8smanifest.VerifyManifest(manifest, vo)

--- a/cmd/kubectl-sigstore/verify.go
+++ b/cmd/kubectl-sigstore/verify.go
@@ -32,12 +32,15 @@ func NewCmdVerify() *cobra.Command {
 	var imageRef string
 	var filename string
 	var keyPath string
+	var configPath string
+	var cacheDir string
+	var useCache bool
 	cmd := &cobra.Command{
 		Use:   "verify -f <YAMLFILE> [-i <IMAGE>]",
 		Short: "A command to verify Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := verify(filename, imageRef, keyPath)
+			err := verify(filename, imageRef, keyPath, configPath, useCache, cacheDir)
 			if err != nil {
 				return err
 			}
@@ -48,11 +51,14 @@ func NewCmdVerify() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be signed (if dir, all YAMLs inside it will be signed)")
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
+	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
+	cmd.PersistentFlags().BoolVar(&useCache, "use-cache", false, "whether to use cache for pulling & verifying image (default: disabled)")
+	cmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", "", "a directory for storing cached data (if empty, not use cache)")
 
 	return cmd
 }
 
-func verify(filename, imageRef, keyPath string) error {
+func verify(filename, imageRef, keyPath, configPath string, useCache bool, cacheDir string) error {
 	manifest, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -67,7 +73,26 @@ func verify(filename, imageRef, keyPath string) error {
 	log.Debug("annotations", annotations)
 	log.Debug("imageRef", imageRef)
 
-	result, err := k8smanifest.Verify(manifest, imageRef, keyPath)
+	vo := &k8smanifest.VerifyManifestOption{}
+	if configPath != "" {
+		vo, err = k8smanifest.LoadVerifyManifestConfig(configPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			return nil
+		}
+	}
+	if imageRef != "" {
+		vo.ImageRef = imageRef
+	}
+	if keyPath != "" {
+		vo.KeyPath = keyPath
+	}
+	if useCache && cacheDir != "" {
+		vo.UseCache = useCache
+		vo.CacheDir = cacheDir
+	}
+
+	result, err := k8smanifest.VerifyManifest(manifest, vo)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil

--- a/example/admission-controller/main.go
+++ b/example/admission-controller/main.go
@@ -104,8 +104,14 @@ func (h *k8sManifestHandler) Handle(ctx context.Context, req admission.Request) 
 		if config.KeySecertName != "" {
 			keyPath, _ = config.LoadKeySecret()
 		}
-		vo := &(config.VerifyOption)
-		result, err := k8smanifest.VerifyResource(obj, imageRef, keyPath, vo)
+		vo := &(config.VerifyResourceOption)
+		if imageRef != "" {
+			vo.ImageRef = imageRef
+		}
+		if keyPath != "" {
+			vo.KeyPath = keyPath
+		}
+		result, err := k8smanifest.VerifyResource(obj, vo)
 		if err != nil {
 			log.Errorf("failed to check a requested resource; %s", err.Error())
 			return admission.Allowed("error but allow for development")

--- a/example/admission-controller/pkg/config/config.go
+++ b/example/admission-controller/pkg/config/config.go
@@ -37,12 +37,12 @@ import (
 const configKeyInConfigMap = "config.yaml"
 
 type ManifestIntegrityConfig struct {
-	k8smanifest.VerifyOption `json:""`
-	InScopeObjects           k8smanifest.ObjectReferenceList `json:"inScopeObjects,omitempty"`
-	SkipUsers                ObjectUserBindingList           `json:"skipUsers,omitempty"`
-	KeySecertName            string                          `json:"keySecretName,omitempty"`
-	KeySecertNamespace       string                          `json:"keySecretNamespace,omitempty"`
-	ImageRef                 string                          `json:"imageRef,omitempty"`
+	k8smanifest.VerifyResourceOption `json:""`
+	InScopeObjects                   k8smanifest.ObjectReferenceList `json:"inScopeObjects,omitempty"`
+	SkipUsers                        ObjectUserBindingList           `json:"skipUsers,omitempty"`
+	KeySecertName                    string                          `json:"keySecretName,omitempty"`
+	KeySecertNamespace               string                          `json:"keySecretNamespace,omitempty"`
+	ImageRef                         string                          `json:"imageRef,omitempty"`
 }
 
 type ObjectUserBindingList []ObjectUserBinding

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -1,0 +1,115 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cosign
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+
+	"github.com/pkg/errors"
+	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
+	k8smnfutil "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util"
+)
+
+const certBeginByte = "-----BEGIN CERTIFICATE-----"
+const certEndByte = "-----END CERTIFICATE-----"
+
+func SignImage(imageRef string, keyPath *string) error {
+	// TODO: check usecase for yaml signing
+	imageAnnotation := map[string]interface{}{}
+
+	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
+	sk := false
+	idToken := ""
+
+	// TODO: handle the case that COSIGN_EXPERIMENTAL env var is not set
+
+	opt := cosigncli.SignOpts{
+		Annotations: imageAnnotation,
+		Sk:          sk,
+		IDToken:     idToken,
+	}
+
+	if keyPath != nil {
+		opt.KeyRef = *keyPath
+		opt.Pf = cosigncli.GetPass
+	}
+
+	return cosigncli.SignCmd(context.Background(), opt, imageRef, true, "", false, false)
+}
+
+func SignBlob(blobPath string, keyPath *string) (map[string][]byte, error) {
+	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
+	sk := false
+	idToken := ""
+
+	opt := cosigncli.KeyOpts{
+		Sk: sk,
+	}
+
+	if keyPath != nil {
+		opt.KeyRef = *keyPath
+	}
+
+	m := map[string][]byte{}
+	rawMsg, err := ioutil.ReadFile(blobPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load a file to be signed")
+	}
+	base64Msg := []byte(base64.StdEncoding.EncodeToString(rawMsg))
+	m["message"] = base64Msg
+
+	returnValArray, stdoutAndErr := k8smnfutil.SilentExecFunc(cosigncli.SignBlobCmd, context.Background(), opt, blobPath, false, cosigncli.GetPass, idToken)
+
+	fmt.Println(stdoutAndErr) // show cosign.SignBlobCmd() logs
+
+	if len(returnValArray) != 2 {
+		return nil, fmt.Errorf("cosign.SignBlobCmd() must return 2 values as output, but got %v values", len(returnValArray))
+	}
+	var rawSig []byte
+	if returnValArray[0] != nil {
+		rawSig = returnValArray[0].([]byte)
+	}
+	if returnValArray[1] != nil {
+		err = returnValArray[1].(error)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "cosign.SignBlobCmd() returned an error")
+	}
+
+	base64Sig := []byte(base64.StdEncoding.EncodeToString(rawSig))
+	m["signature"] = base64Sig
+
+	rawCert := extractCertFromStdoutAndErr(stdoutAndErr)
+	gzipCert := k8smnfutil.GzipCompress(rawCert)
+	base64Cert := []byte(base64.StdEncoding.EncodeToString(gzipCert))
+	m["certificate"] = base64Cert
+
+	return m, nil
+}
+
+func extractCertFromStdoutAndErr(stdoutAndErr string) []byte {
+	re := regexp.MustCompile(fmt.Sprintf(`(?s)%s.*%s`, certBeginByte, certEndByte)) // `(?s)` is necessary for matching multi lines
+	foundBlocks := re.FindAllString(stdoutAndErr, 1)
+	if len(foundBlocks) == 0 {
+		return nil
+	}
+	return []byte(foundBlocks[0])
+}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1,0 +1,159 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cosign
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/cosign/fulcio"
+	"github.com/sigstore/sigstore/pkg/signature/payload"
+	k8smnfutil "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util"
+)
+
+const (
+	tmpMessageFile     = "k8s-manifest-sigstore-message"
+	tmpCertificateFile = "k8s-manifest-sigstore-certificate"
+	tmpSignatureFile   = "k8s-manifest-sigstore-signature"
+)
+
+func VerifyImage(imageRef string, pubkeyPath *string) (bool, string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse image ref `%s`; %s", imageRef, err.Error())
+	}
+
+	co := &cosign.CheckOpts{
+		Claims: true,
+		Tlog:   true,
+		Roots:  fulcio.Roots,
+	}
+
+	if pubkeyPath != nil && *pubkeyPath != "" {
+		tmpPubkey, err := cosign.LoadPublicKey(context.Background(), *pubkeyPath)
+		if err != nil {
+			return false, "", fmt.Errorf("error loading public key; %s", err.Error())
+		}
+		co.PubKey = tmpPubkey
+	}
+
+	rekorSever := cli.TlogServer()
+	verified, err := cosign.Verify(context.Background(), ref, co, rekorSever)
+	if err != nil {
+		return false, "", fmt.Errorf("error occured while verifying image `%s`; %s", imageRef, err.Error())
+	}
+	if len(verified) == 0 {
+		return false, "", fmt.Errorf("no verified signatures in the image `%s`; %s", imageRef, err.Error())
+	}
+	var cert *x509.Certificate
+	for _, vp := range verified {
+		ss := payload.SimpleContainerImage{}
+		err := json.Unmarshal(vp.Payload, &ss)
+		if err != nil {
+			continue
+		}
+		cert = vp.Cert
+		break
+	}
+	signerName := "" // singerName could be empty in case of key-used verification
+	if cert != nil {
+		signerName = k8smnfutil.GetNameInfoFromCert(cert)
+	}
+	return true, signerName, nil
+}
+
+func VerifyBlob(msgBytes, sigBytes, certBytes []byte, pubkeyPath *string) (bool, string, error) {
+	dir, err := ioutil.TempDir("", "kubectl-sigstore-temp-dir")
+	if err != nil {
+		return false, "", err
+	}
+	defer os.RemoveAll(dir)
+
+	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
+	sk := false
+
+	opt := cli.KeyOpts{
+		Sk: sk,
+	}
+
+	if pubkeyPath != nil {
+		opt.KeyRef = *pubkeyPath
+	}
+
+	gzipMsg, _ := base64.StdEncoding.DecodeString(string(msgBytes))
+	rawSig, _ := base64.StdEncoding.DecodeString(string(sigBytes))
+	gzipCert, _ := base64.StdEncoding.DecodeString(string(certBytes))
+	rawCert := k8smnfutil.GzipDecompress(gzipCert)
+	msgFile := filepath.Join(dir, tmpMessageFile)
+	sigFile := filepath.Join(dir, tmpSignatureFile)
+	certFile := filepath.Join(dir, tmpCertificateFile)
+	_ = ioutil.WriteFile(msgFile, gzipMsg, 0777) // signed blob is .tar.gz, so create gzip bytes
+	_ = ioutil.WriteFile(sigFile, rawSig, 0777)
+	_ = ioutil.WriteFile(certFile, rawCert, 0777)
+
+	returnValArray, stdoutAndErr := k8smnfutil.SilentExecFunc(cli.VerifyBlobCmd, context.Background(), opt, certFile, sigFile, msgFile)
+	if len(returnValArray) != 1 {
+		return false, "", fmt.Errorf("cosign.VerifyBlobCmd() must return 1 values as output, but got %v values", len(returnValArray))
+	}
+	if returnValArray[0] != nil {
+		err = returnValArray[0].(error)
+	}
+	if err != nil {
+		err = fmt.Errorf("error: %s, detail logs during cosign.VerifyBlobCmd(): %s", err.Error(), stdoutAndErr)
+		return false, "", errors.Wrap(err, "cosign.VerifyBlobCmd() returned an error")
+	}
+	verified := false
+	if err == nil {
+		verified = true
+	}
+
+	cert, err := loadCertificate(rawCert)
+	if err != nil {
+		return false, "", errors.Wrap(err, "failed to load certificate")
+	}
+	signerName := getNameInfoFromCert(cert)
+
+	return verified, signerName, nil
+}
+
+func loadCertificate(pemBytes []byte) (*x509.Certificate, error) {
+	p, _ := pem.Decode(pemBytes)
+	if p == nil {
+		return nil, errors.New("failed to decode PEM bytes")
+	}
+	return x509.ParseCertificate(p.Bytes)
+}
+
+func getNameInfoFromCert(cert *x509.Certificate) string {
+	name := ""
+	if len(cert.EmailAddresses) > 0 {
+		name = cert.EmailAddresses[0]
+	}
+	return name
+}

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -24,10 +24,37 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type VerifyOption struct {
-	SkipObjects  ObjectReferenceList    `json:"skipObjects,omitempty"`
+// option for Sign()
+type SignOption struct {
+	// these options should be input from CLI arguments
+	KeyPath          string `json:"-"`
+	ImageRef         string `json:"-"`
+	Output           string `json:"-"`
+	UpdateAnnotation bool   `json:"-"`
+}
+
+// option for VerifyResource()
+type VerifyResourceOption struct {
+	verifyOption `json:""`
+	SkipObjects  ObjectReferenceList `json:"skipObjects,omitempty"`
+}
+
+// option for VerifyManifest()
+type VerifyManifestOption struct {
+	verifyOption `json:""`
+}
+
+// common options for verify functions
+// this verifyOption should not be used directly by those functions
+type verifyOption struct {
 	IgnoreFields ObjectFieldBindingList `json:"ignoreFields,omitempty"`
 	Signers      SignerList             `json:"signers,omitempty"`
+
+	// these options should be input from CLI arguments
+	KeyPath  string `json:"-"`
+	ImageRef string `json:"-"`
+	UseCache bool   `json:"-"`
+	CacheDir string `json:"-"`
 }
 
 type ObjectReference struct {
@@ -122,12 +149,25 @@ func (l SignerList) Match(signerName string) bool {
 	return false
 }
 
-func LoadVerifyConfig(fpath string) (*VerifyOption, error) {
+func LoadVerifyManifestConfig(fpath string) (*VerifyManifestOption, error) {
 	cfgBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}
-	var option *VerifyOption
+	var option *VerifyManifestOption
+	err = yaml.Unmarshal(cfgBytes, &option)
+	if err != nil {
+		return nil, err
+	}
+	return option, nil
+}
+
+func LoadVerifyResourceConfig(fpath string) (*VerifyResourceOption, error) {
+	cfgBytes, err := os.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+	var option *VerifyResourceOption
 	err = yaml.Unmarshal(cfgBytes, &option)
 	if err != nil {
 		return nil, err

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -39,7 +39,7 @@ const (
 	SignatureAnnotationKey   = "cosign.sigstore.dev/siganture"
 	CertificateAnnotationKey = "cosign.sigstore.dev/certificate"
 	MessageAnnotationKey     = "cosign.sigstore.dev/message"
-	BundleAnnotationKey      = "cosign.sigstore.dev/bundle"
+	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far
 )
 
 var annotationKeyMap = map[string]string{

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	ImageRefAnnotationKey    = "cosign.sigstore.dev/imageRef"
-	SignatureAnnotationKey   = "cosign.sigstore.dev/siganture"
+	SignatureAnnotationKey   = "cosign.sigstore.dev/signature"
 	CertificateAnnotationKey = "cosign.sigstore.dev/certificate"
 	MessageAnnotationKey     = "cosign.sigstore.dev/message"
 	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -18,7 +18,6 @@ package k8smanifest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,10 +27,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	k8scosign "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/cosign"
 	k8ssigutil "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util"
 	"github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util/mapnode"
 
-	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
 )
 
@@ -43,41 +42,119 @@ const (
 	BundleAnnotationKey      = "cosign.sigstore.dev/bundle"
 )
 
-func Sign(inputDir, imageRef, keyPath, output string, updateAnnotation bool) ([]byte, error) {
+var annotationKeyMap = map[string]string{
+	"signature":   SignatureAnnotationKey,
+	"certificate": CertificateAnnotationKey,
+	"message":     MessageAnnotationKey,
+	"bundle":      BundleAnnotationKey,
+	"imageRef":    ImageRefAnnotationKey,
+}
+
+func Sign(inputDir string, so *SignOption) ([]byte, error) {
+
+	output := ""
+	if so.UpdateAnnotation {
+		output = so.Output
+	}
+
+	signedBytes, err := NewSigner(so.ImageRef, so.KeyPath).Sign(inputDir, output)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign the specified content")
+	}
+
+	return signedBytes, nil
+}
+
+type Signer interface {
+	Sign(inputDir, output string) ([]byte, error)
+}
+
+func NewSigner(imageRef, keyPath string) Signer {
+	var prikeyPath *string
+	if keyPath != "" {
+		prikeyPath = &keyPath
+	}
+	if imageRef == "" {
+		return &AnnotationSigner{prikeyPath: prikeyPath}
+	} else {
+		return &ImageSigner{imageRef: imageRef, prikeyPath: prikeyPath}
+	}
+}
+
+type ImageSigner struct {
+	imageRef   string
+	prikeyPath *string
+}
+
+func (s *ImageSigner) Sign(inputDir, output string) ([]byte, error) {
 	var inputDataBuffer bytes.Buffer
 	err := k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compress an input file/dir")
 	}
 	var signedBytes []byte
-
-	if imageRef != "" {
-		// upload files as image
-		err := uploadFileToRegistry(inputDataBuffer.Bytes(), imageRef)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to upload image with manifest")
-		}
-		// sign the image
-		err = signImage(imageRef, keyPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to sign image")
-		}
-		if updateAnnotation {
-			// generate a signed YAML file
-			signedBytes, err = generateSignedYAMLManifest(inputDir, imageRef, nil)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to generate a signed YAML")
-			}
-			err = ioutil.WriteFile(output, signedBytes, 0644)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to write a signed YAML into")
-			}
-		}
-	} else {
-		// TODO: support annotation signature instead of error
-		return nil, errors.New("imageRef is empty")
+	// upload files as image
+	err = uploadFileToRegistry(inputDataBuffer.Bytes(), s.imageRef)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to upload image with manifest")
 	}
+	// sign the image
+	err = k8scosign.SignImage(s.imageRef, s.prikeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign image")
+	}
+	if output != "" {
+		// generate a signed YAML file
+		signedBytes, err = generateSignedYAMLManifest(inputDir, s.imageRef, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate a signed YAML")
+		}
+		err = ioutil.WriteFile(output, signedBytes, 0644)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to write a signed YAML into")
+		}
+	}
+	return signedBytes, nil
+}
 
+type AnnotationSigner struct {
+	prikeyPath *string
+}
+
+func (s *AnnotationSigner) Sign(inputDir, output string) ([]byte, error) {
+	var inputDataBuffer bytes.Buffer
+	dir, err := ioutil.TempDir("", "kubectl-sigstore-temp-dir")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a temporary directory for signing")
+	}
+	defer os.RemoveAll(dir)
+	tmpBlobFile := filepath.Join(dir, "tmp-blob-file")
+
+	err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compress an input file/dir")
+	}
+	var signedBytes []byte
+	var sigMaps map[string][]byte
+	err = ioutil.WriteFile(tmpBlobFile, inputDataBuffer.Bytes(), 0777)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a temporary blob file")
+	}
+	sigMaps, err = k8scosign.SignBlob(tmpBlobFile, s.prikeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign a blob file")
+	}
+	if output != "" {
+		// generate a signed YAML file
+		signedBytes, err = generateSignedYAMLManifest(inputDir, "", sigMaps)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate a signed YAML")
+		}
+		err = ioutil.WriteFile(output, signedBytes, 0644)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to write a signed YAML into")
+		}
+	}
 	return signedBytes, nil
 }
 
@@ -110,30 +187,6 @@ func uploadFileToRegistry(inputData []byte, imageRef string) error {
 	return nil
 }
 
-func signImage(imageRef, keyPath string) error {
-	// TODO: check usecase for yaml signing
-	imageAnnotation := map[string]interface{}{}
-
-	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
-	sk := false
-	idToken := ""
-
-	// TODO: handle the case that COSIGN_EXPERIMENTAL env var is not set
-
-	opt := cosigncli.SignOpts{
-		Annotations: imageAnnotation,
-		Sk:          sk,
-		IDToken:     idToken,
-	}
-
-	if keyPath != "" {
-		opt.KeyRef = keyPath
-		opt.Pf = cosigncli.GetPass
-	}
-
-	return cosigncli.SignCmd(context.Background(), opt, imageRef, true, "", false, false)
-}
-
 func generateSignedYAMLManifest(inputDir, imageRef string, sigMaps map[string][]byte) ([]byte, error) {
 	if imageRef == "" && len(sigMaps) == 0 {
 		return nil, errors.New("either image ref or signature infos are required for generating a signed YAML")
@@ -147,8 +200,13 @@ func generateSignedYAMLManifest(inputDir, imageRef string, sigMaps map[string][]
 	annotationMap := map[string]interface{}{}
 	if imageRef != "" {
 		annotationMap[ImageRefAnnotationKey] = imageRef
-	} else {
-		// TODO: support annotation signature
+	} else if sigMaps != nil {
+		for key, val := range sigMaps {
+			annoKey, ok := annotationKeyMap[key]
+			if ok {
+				annotationMap[annoKey] = string(val)
+			}
+		}
 	}
 
 	signedYAMLs := [][]byte{}

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -58,8 +58,6 @@ func NewSignatureVerifier(objYAMLBytes []byte, imageRef string) SignatureVerifie
 
 type ImageSignatureVerifier struct {
 	imageRef string
-	useCache bool
-	cacheDir string
 }
 
 func (v *ImageSignatureVerifier) Verify(pubkeyPath *string) (bool, string, error) {
@@ -112,8 +110,6 @@ func NewManifestFetcher(imageRef string) ManifestFetcher {
 // ImageManifestFetcher is a fetcher implementation for image reference
 type ImageManifestFetcher struct {
 	imageRef string
-	useCache bool
-	cacheDir string
 }
 
 func (f *ImageManifestFetcher) Fetch(objYAMLBytes []byte) ([]byte, bool, error) {

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -1,0 +1,133 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package k8smanifest
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	k8ssigutil "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util"
+	mapnode "github.com/yuji-watanabe-jp/k8s-manifest-sigstore/pkg/util/mapnode"
+)
+
+func VerifyManifest(manifest []byte, vo *VerifyManifestOption) (*VerifyResult, error) {
+	if manifest == nil {
+		return nil, errors.New("input YAML manifest must be non-empty")
+	}
+
+	var obj unstructured.Unstructured
+	_ = yaml.Unmarshal(manifest, &obj)
+
+	verified := false
+	signerName := ""
+	var err error
+
+	// get ignore fields configuration for this resource if found
+	ignoreFields := []string{}
+	if vo != nil {
+		if ok, fields := vo.IgnoreFields.Match(obj); ok {
+			ignoreFields = fields
+		}
+	}
+
+	var manifestInRef []byte
+	var manifestInRefFound bool
+	manifestInRef, manifestInRefFound, err = NewManifestFetcher(vo.ImageRef).Fetch(manifest)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch YAML manifest")
+	}
+	if !manifestInRefFound {
+		return &VerifyResult{
+			Verified: false,
+		}, nil
+	}
+
+	matched, diff, err := matchManifest(manifest, manifestInRef, ignoreFields)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to match manifest")
+	}
+	if !matched {
+		return &VerifyResult{
+			Verified: false,
+			Signer:   "",
+			Diff:     diff,
+		}, nil
+	}
+
+	var keyPath *string
+	if vo.KeyPath != "" {
+		keyPath = &(vo.KeyPath)
+	}
+
+	verified, signerName, err = NewSignatureVerifier(manifest, vo.ImageRef).Verify(keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "error occured during signature verification")
+	}
+	if verified {
+		if !vo.Signers.Match(signerName) {
+			verified = false
+		}
+	}
+
+	return &VerifyResult{
+		Verified: verified,
+		Signer:   signerName,
+	}, nil
+}
+
+func matchManifest(manifest, manifestInRef []byte, ignoreFields []string) (bool, *mapnode.DiffResult, error) {
+	log.Debug("manifest:", string(manifest))
+	log.Debug("manifest in reference:", string(manifestInRef))
+	inputFileNode, err := mapnode.NewFromYamlBytes(manifest)
+	if err != nil {
+		return false, nil, err
+	}
+	maskedInputNode := inputFileNode.Mask(EmbeddedAnnotationMaskKeys)
+
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(manifest, &obj)
+	if err != nil {
+		return false, nil, err
+	}
+	apiVersion := obj.GetAPIVersion()
+	kind := obj.GetKind()
+	name := obj.GetName()
+	namespace := obj.GetNamespace()
+	found, foundBytes := k8ssigutil.FindSingleYaml(manifestInRef, apiVersion, kind, name, namespace)
+	if !found {
+		return false, nil, errors.New("failed to find the YAML manifest")
+	}
+	manifestNode, err := mapnode.NewFromYamlBytes(foundBytes)
+	if err != nil {
+		return false, nil, err
+	}
+	maskedManifestNode := manifestNode.Mask(EmbeddedAnnotationMaskKeys)
+	var matched bool
+	diff := maskedInputNode.Diff(maskedManifestNode)
+
+	// filter out ignoreFields
+	if diff != nil && len(ignoreFields) > 0 {
+		_, diff, _ = diff.Filter(ignoreFields)
+	}
+	if diff == nil || diff.Size() == 0 {
+		matched = true
+		diff = nil
+	}
+	return matched, diff, nil
+}

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -75,7 +75,7 @@ func VerifyManifest(manifest []byte, vo *VerifyManifestOption) (*VerifyResult, e
 		keyPath = &(vo.KeyPath)
 	}
 
-	verified, signerName, err = NewSignatureVerifier(manifest, vo.ImageRef).Verify(keyPath)
+	verified, signerName, err = NewSignatureVerifier(manifest, vo.ImageRef, keyPath).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "error occured during signature verification")
 	}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -130,7 +130,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		keyPath = &(vo.KeyPath)
 	}
 
-	verified, signerName, err = NewSignatureVerifier(objBytes, vo.ImageRef).Verify(keyPath)
+	verified, signerName, err = NewSignatureVerifier(objBytes, vo.ImageRef, keyPath).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "error occured during signature verification")
 	}

--- a/pkg/util/exec.go
+++ b/pkg/util/exec.go
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func CmdExec(baseCmd string, args ...string) (string, error) {
+	cmd := exec.Command(baseCmd, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", errors.Wrap(err, stderr.String())
+	}
+	out := stdout.String()
+	return out, nil
+}
+
+func SilentExecFunc(f interface{}, i ...interface{}) ([]interface{}, string) {
+	// if f is not a function, exit this
+	if reflect.ValueOf(f).Type().Kind() != reflect.Func {
+		return nil, ""
+	}
+
+	// create virtual output
+	rStdout, wStdout, _ := os.Pipe()
+	rStderr, wStderr, _ := os.Pipe()
+	channel := make(chan string)
+
+	// backup all output
+	backupStdout := os.Stdout
+	backupStderr := os.Stderr
+
+	// overwrite output configuration with virtual output
+	os.Stdout = wStdout
+	os.Stderr = wStderr
+
+	// set a channel as a stdout buffer
+	go func(out chan string, readerStdout *os.File, readerStderr *os.File) {
+		var bufStdout bytes.Buffer
+		_, _ = io.Copy(&bufStdout, readerStdout)
+		if bufStdout.Len() > 0 {
+			out <- bufStdout.String()
+		}
+
+		var bufStderr bytes.Buffer
+		_, _ = io.Copy(&bufStderr, readerStderr)
+		if bufStderr.Len() > 0 {
+			out <- bufStderr.String()
+		}
+	}(channel, rStdout, rStderr)
+
+	// configure channel so that all recevied string would be inserted into vStdout
+	vStdout := ""
+	go func() {
+		for {
+			select {
+			case out := <-channel:
+				vStdout += out
+			}
+		}
+	}()
+
+	// call the function
+	in := []reflect.Value{}
+	for _, ii := range i {
+		in = append(in, reflect.ValueOf(ii))
+	}
+	o := []interface{}{}
+	out := reflect.ValueOf(f).Call(in)
+	for _, oi := range out {
+		o = append(o, oi.Interface())
+	}
+
+	// close vitual output
+	_ = wStdout.Close()
+	_ = wStderr.Close()
+	time.Sleep(10 * time.Millisecond)
+
+	// restore original output configuration
+	os.Stdout = backupStdout
+	os.Stderr = backupStderr
+	return o, vStdout
+}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -73,7 +73,7 @@ func GenerateConcatYAMLsFromImage(img v1.Image) ([]byte, error) {
 			continue
 		}
 		blobStream := bytes.NewBuffer(blob)
-		yamlsInLayer, err := getYAMLsInArtifact(blobStream)
+		yamlsInLayer, err := GetYAMLsInArtifact(blobStream)
 		if err != nil {
 			sumErr = append(sumErr, errors.Wrap(err, "failed to decompress tar gz blob").Error())
 			continue
@@ -87,7 +87,7 @@ func GenerateConcatYAMLsFromImage(img v1.Image) ([]byte, error) {
 	return concatYamls, nil
 }
 
-func getYAMLsInArtifact(gzipStream io.Reader) ([][]byte, error) {
+func GetYAMLsInArtifact(gzipStream io.Reader) ([][]byte, error) {
 	uncompressedStream, err := gzip.NewReader(gzipStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "gzip.NewReader() failed while decompressing tar gz")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,21 +18,24 @@ package util
 
 import (
 	"bytes"
-	"os/exec"
-
-	"github.com/pkg/errors"
+	"compress/gzip"
+	"io/ioutil"
 )
 
-func CmdExec(baseCmd string, args ...string) (string, error) {
-	cmd := exec.Command(baseCmd, args...)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
+func GzipCompress(in []byte) []byte {
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	writer.Write(in)
+	writer.Close()
+	return buffer.Bytes()
+}
+
+func GzipDecompress(in []byte) []byte {
+	reader := bytes.NewReader(in)
+	gzreader, _ := gzip.NewReader(reader)
+	out, err := ioutil.ReadAll(gzreader)
 	if err != nil {
-		return "", errors.Wrap(err, stderr.String())
+		return in
 	}
-	out := stdout.String()
-	return out, nil
+	return out
 }

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -70,6 +70,19 @@ func FindYAMLsInDir(dirPath string) ([][]byte, error) {
 	return foundYAMLs, nil
 }
 
+func FindManifestYAML(concatYamlBytes, objBytes []byte) (bool, []byte) {
+	var obj *unstructured.Unstructured
+	err := yaml.Unmarshal(objBytes, &obj)
+	if err != nil {
+		return false, nil
+	}
+	apiVersion := obj.GetAPIVersion()
+	kind := obj.GetKind()
+	name := obj.GetName()
+	namespace := obj.GetNamespace()
+	return FindSingleYaml(concatYamlBytes, apiVersion, kind, name, namespace)
+}
+
 func FindSingleYaml(concatYamlBytes []byte, apiVersion, kind, name, namespace string) (bool, []byte) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>


This change enables users to sign a YAML manifest without OCI image.
Instead, a signature and some other data will be attached to YAML annotations.
Then users can verify the signature only by specifying the signed YAML file, and it does not require any OCI image access.

Usage will be like the following.
```
# sign
$ kubectl sigstore sign -f sample-manifest.yaml

# check signed YAML
$ cat sample-manifest.yaml.signed | grep signature
    cosign.sigstore.dev/signature: MEUC ... gOE=

# verify
$ kubectl sigstore verify -f sample-manifest.yaml.signed
```